### PR TITLE
fix: use `basename` for react-router

### DIFF
--- a/packages/urlstate/react-router/useUrlState/useUrlState.ts
+++ b/packages/urlstate/react-router/useUrlState/useUrlState.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   type NavigateOptions,
+  useHref,
   useNavigate,
   useSearchParams,
 } from "react-router-dom";
@@ -161,14 +162,20 @@ export function useUrlState<T extends JSONCompatible>(
 
   const [sp] = useSearchParams();
 
+  const basename = useHref("/");
+
   const {
     state,
     updateState,
     updateUrl: updateUrlBase,
     getState,
     reset: resetBase,
-  } = useUrlStateBase(_defaultState, router, ({ parse }) =>
-    parse(filterUnknownParamsClient(_defaultState, sp.entries())),
+  } = useUrlStateBase(
+    _defaultState,
+    router,
+    ({ parse }) =>
+      parse(filterUnknownParamsClient(_defaultState, sp.entries())),
+    basename,
   );
 
   const updateUrl = React.useCallback(

--- a/packages/urlstate/useUrlStateBase/useUrlStateBase.test.ts
+++ b/packages/urlstate/useUrlStateBase/useUrlStateBase.test.ts
@@ -581,4 +581,111 @@ describe('useUrlStateBase', () => {
       expect(result.current.state).toStrictEqual({ ...shape, num: 55 });
     });
   });
+
+  describe('basename prop', () => {
+    test('basename /base and url /base', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout']
+      });
+      vi.mocked(utils).isSSR = false;
+      const pathname = '/base';
+
+      const originalLocation = window.location;
+      vi.spyOn(window, 'location', 'get').mockImplementation(() => ({
+        ...originalLocation,
+        pathname,
+        search: '',
+        hash: '',
+      }));
+
+      const { result } = renderHook(() => useUrlStateBase(shape, router, undefined, '/base'));
+
+      act(() => {
+        result.current.updateUrl({ ...shape, num: 50 });
+      });
+
+      await vi.advanceTimersByTime(700);
+      await vi.advanceTimersByTime(700);
+
+      expect(result.current.state).toStrictEqual({ ...shape, num: 50 });
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenNthCalledWith(1, '/?num=50', {});
+    });
+
+    test('basename /base and url /base/other', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout']
+      });
+
+      const pathname = '/base/other';
+
+      const originalLocation = window.location;
+      vi.spyOn(window, 'location', 'get').mockImplementation(() => ({
+        ...originalLocation,
+        pathname,
+        search: '',
+        hash: '',
+      }));
+      vi.mocked(utils).isSSR = false;
+      const { result } = renderHook(() => useUrlStateBase(shape, router, undefined, '/base'));
+
+      act(() => {
+        result.current.updateUrl({ ...shape, num: 50 });
+      });
+
+      await vi.advanceTimersByTime(700);
+      await vi.advanceTimersByTime(700);
+
+      expect(result.current.state).toStrictEqual({ ...shape, num: 50 });
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenNthCalledWith(1, '/other?num=50', {});
+    });
+
+    test('basename / and url /', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout']
+      });
+      vi.mocked(utils).isSSR = false;
+      const pathname = '/';
+
+      const originalLocation = window.location;
+      vi.spyOn(window, 'location', 'get').mockImplementation(() => ({
+        ...originalLocation,
+        pathname,
+        search: '',
+        hash: '',
+      }));
+      const { result } = renderHook(() => useUrlStateBase(shape, router, undefined, '/'));
+
+      act(() => {
+        result.current.updateUrl({ ...shape, num: 50 });
+      });
+
+      await vi.advanceTimersByTime(700);
+      await vi.advanceTimersByTime(700);
+
+      expect(result.current.state).toStrictEqual({ ...shape, num: 50 });
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenNthCalledWith(1, '/?num=50', {});
+    });
+
+    test('basename empty', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout']
+      });
+      vi.mocked(utils).isSSR = false;
+      const { result } = renderHook(() => useUrlStateBase(shape, router, undefined, ''));
+
+      act(() => {
+        result.current.updateUrl({ ...shape, num: 50 });
+      });
+
+      await vi.advanceTimersByTime(700);
+      await vi.advanceTimersByTime(700);
+
+      expect(result.current.state).toStrictEqual({ ...shape, num: 50 });
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenNthCalledWith(1, '/?num=50', {});
+    });
+  })
 });

--- a/packages/urlstate/useUrlStateBase/useUrlStateBase.ts
+++ b/packages/urlstate/useUrlStateBase/useUrlStateBase.ts
@@ -52,6 +52,7 @@ export function useUrlStateBase<T extends JSONCompatible>(
   }: {
     parse: ReturnType<typeof useUrlEncode<T>>["parse"];
   }) => T,
+  basename?: string,
 ) {
   const { parse, stringify } = useUrlEncode(defaultState);
   const { state, getState, setState } = useSharedState(
@@ -96,8 +97,9 @@ export function useUrlStateBase<T extends JSONCompatible>(
 
       const qStr = stringify(newVal, getOtherParams(defaultState));
 
-      const newUrl = `${window.location.pathname}${qStr.length ? "?" : ""}${qStr}${window.location.hash}`;
-      const currUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const base = removeBasename(window.location.pathname, basename);
+      const newUrl = `${base}${qStr.length ? "?" : ""}${qStr}${window.location.hash}`;
+      const currUrl = `${base}${window.location.search}${window.location.hash}`;
       if (newUrl === currUrl) return;
 
       setState(newVal);
@@ -169,4 +171,13 @@ export interface Options extends OptionsObject {
 
 function getSearch() {
   return (typeof window !== "undefined" && window.location.search) || "";
+}
+
+function removeBasename(path: string, basename?: string) {
+  if (!basename || basename === "/") {
+    return path;
+  }
+
+  const result = path.slice(basename.length);
+  return result.startsWith("/") ? result : "/" + result;
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   // workers: process.env.CI ? 1 : undefined,
-  workers: process.env.CI ? 1 : 2,
+  workers: process.env.CI ? 1 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'blob' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
fix [#52](https://github.com/asmyshlyaev177/state-in-url/issues/52)

Please follow [contributing guidelines](/CONTRIBUTING.md)

[comment]: # (What it's about. Adding feature or fixing a bug)
# PR title

[comment]: # (Description of changes)
## Proposed Changes
  - use `basename` when constructing the url

[comment]: # (Fill out if it change or break existing API)
## Breaking Changes
